### PR TITLE
correctly handle class names translated by babele

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -145,7 +145,8 @@
       "levelUpStart": "Updating {actorName} to level {targetLevel}...",
       "levelUpComplete": "{actorName} level up complete!",
       "wizardStartup": "Starting up Level-Up Wizard...",
-      "missingClass": "Level-Up Wizard cannot start until a class is selected."
+      "missingClass": "Level-Up Wizard cannot start until a class is selected.",
+      "translatedDualClassError": "Level-Up Wizard cannot be used with translated dual classes"
     }
   }
 }

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -145,7 +145,8 @@
       "levelUpStart": "Aktualizacja {actorName} do poziomu {targetLevel}...",
       "levelUpComplete": "Aktualizacja poziomu {actorName} zakończona!",
       "wizardStartup": "Uruchamianie Level-Up Wizard...",
-      "missingClass": "Level-Up Wizard nie może zostać uruchomiony, dopóki nie zostanie wybrana klasa."
+      "missingClass": "Level-Up Wizard nie może zostać uruchomiony, dopóki nie zostanie wybrana klasa.",
+      "translatedDualClassError": "Level-Up nie może być używany z przetłumaczonymi klasami dualnymi"
     }
   }
 }

--- a/src/featSelector.js
+++ b/src/featSelector.js
@@ -288,14 +288,15 @@ export class FeatSelector extends foundry.applications.api.ApplicationV2 {
       const matchesArchetype =
         includeArchetypeFeats ||
         !feat.system.traits.value.includes('archetype');
-      const matchesDedicationSearch =
+      
+      const dedicationTranslated= game.i18n.localize('PF2E.TraitDedication').toLowerCase();
+      const matchesDedicationSearch = 
         !this.filters.dedicationSearch ||
         feat.system.prerequisites?.value?.some((prereq) => {
           const prerequisiteValue = prereq.value.toLowerCase();
           return (
             prerequisiteValue.includes(this.filters.dedicationSearch) &&
-            // TODO: This could become ugly if more languages are coming. Should maybe just be removed? Or alternatively look for a way to get the translation for 'dedication' from the system...
-            (prerequisiteValue.includes('dedication') || prerequisiteValue.includes('zugang'))
+            (prerequisiteValue.includes('dedication') || prerequisiteValue.includes(dedicationTranslated))
           );
         });
 

--- a/src/featSelector.js
+++ b/src/featSelector.js
@@ -1,6 +1,5 @@
 import { createFeatChatMessage } from './helpers/foundryHelpers.js';
 import { getAssociatedSkills, getSkillTranslation, SKILLS } from './helpers/skillsHelpers.js';
-import { capitalize } from './helpers/utility.js';
 
 export class FeatSelector extends foundry.applications.api.ApplicationV2 {
   constructor(feats, featType, actorName, targetLevel, options) {

--- a/src/featSelector.js
+++ b/src/featSelector.js
@@ -1,5 +1,5 @@
 import { createFeatChatMessage } from './helpers/foundryHelpers.js';
-import { getAssociatedSkills, SKILLS } from './helpers/skillsHelpers.js';
+import { getAssociatedSkills, getSkillTranslation, SKILLS } from './helpers/skillsHelpers.js';
 import { capitalize } from './helpers/utility.js';
 
 export class FeatSelector extends foundry.applications.api.ApplicationV2 {
@@ -67,7 +67,7 @@ export class FeatSelector extends foundry.applications.api.ApplicationV2 {
     );
     const localizedSkills = SKILLS.map((skill) => ({
       key: skill,
-      label: game.i18n.localize(`PF2E.Skill.${capitalize(skill)}`)
+      label: getSkillTranslation(skill)
     }));
 
     this.filteredFeats.forEach((feat) => {
@@ -176,7 +176,7 @@ export class FeatSelector extends foundry.applications.api.ApplicationV2 {
     // Event: Select Skill
     skillFilter.on('change', 'input[type="checkbox"]', (e) => {
       const skill = e.target.value;
-
+      
       if (e.target.checked) {
         this.filters.skills.push(skill);
       } else {

--- a/src/featSelector.js
+++ b/src/featSelector.js
@@ -288,14 +288,14 @@ export class FeatSelector extends foundry.applications.api.ApplicationV2 {
       const matchesArchetype =
         includeArchetypeFeats ||
         !feat.system.traits.value.includes('archetype');
-
       const matchesDedicationSearch =
         !this.filters.dedicationSearch ||
         feat.system.prerequisites?.value?.some((prereq) => {
           const prerequisiteValue = prereq.value.toLowerCase();
           return (
             prerequisiteValue.includes(this.filters.dedicationSearch) &&
-            prerequisiteValue.includes('dedication')
+            // TODO: This could become ugly if more languages are coming. Should maybe just be removed? Or alternatively look for a way to get the translation for 'dedication' from the system...
+            (prerequisiteValue.includes('dedication') || prerequisiteValue.includes('zugang'))
           );
         });
 

--- a/src/helpers/classFeaturesHelpers.js
+++ b/src/helpers/classFeaturesHelpers.js
@@ -98,7 +98,7 @@ const mapFeaturesWithDetails = async (features, characterClass) => {
       );
 
       return {
-        name: feature.name,
+        name: item.name,
         description: enrichedDescription,
         img: feature.img || item.img,
         uuid: feature.uuid

--- a/src/helpers/foundryHelpers.js
+++ b/src/helpers/foundryHelpers.js
@@ -3,12 +3,27 @@ import { module_name } from '../main.js';
 import { capitalize } from './utility.js';
 
 export const renderWizard = (actor, manualLevelUp) => {
-  actor.class
-    ? new PF2eLevelUpWizardConfig(actor, manualLevelUp).render(true)
-    : ui.notifications.info(
-        game.i18n.localize('PF2E_LEVEL_UP_WIZARD.notifications.missingClass')
-      );
+  if(validateActor(actor)) {
+    new PF2eLevelUpWizardConfig(actor, manualLevelUp).render(true);
+  }
 };
+
+export const validateActor = (actor) => {
+  if(!actor.class) {
+    ui.notifications.info(
+      game.i18n.localize('PF2E_LEVEL_UP_WIZARD.notifications.missingClass')
+    );
+    return false;
+  }
+  // If the actor has a dual class translated with babele, there seems to be no way to properly filter the class feats
+  if (actor.class.flags.babele?.translated && actor.class.name.indexOf('-') > -1) {
+    ui.notifications.error(
+      game.i18n.localize('PF2E_LEVEL_UP_WIZARD.notifications.translatedDualClassError')
+    );
+    return false;
+  }
+  return true;
+}
 
 export const confirmChanges = async () => {
   return foundry.applications.api.DialogV2.confirm({

--- a/src/helpers/skillsHelpers.js
+++ b/src/helpers/skillsHelpers.js
@@ -1,3 +1,4 @@
+import { capitalize } from './utility.js';
 export const skillProficiencyRanks = {
   0: 'Untrained',
   1: 'Trained',
@@ -42,10 +43,21 @@ export const SKILLS = [
   'thievery'
 ];
 
+
+
 export const getMaxSkillProficiency = (level) => {
   if (level >= 15) return 4; // Legendary
   if (level >= 7) return 3; // Master
   return 2; // Expert
+};
+
+const SKILL_TRANSLATIONS_MAP = {};
+
+export const getSkillTranslation= (skill) => {
+  if(!SKILL_TRANSLATIONS_MAP[skill]) {
+    SKILL_TRANSLATIONS_MAP[skill] = game.i18n.localize(`PF2E.Skill.${capitalize(skill)}`);
+  }
+  return  SKILL_TRANSLATIONS_MAP[skill];
 };
 
 export const getSkillsForLevel = (characterData, targetLevel) => {
@@ -69,6 +81,7 @@ export const getAssociatedSkills = (prerequisites) => {
     .flatMap((prereq) => {
       const matches = SKILLS.filter((skill) =>
         new RegExp(`\\b${skill}\\b`, 'i').test(prereq.value)
+        || new RegExp(`\\b${getSkillTranslation(skill)}\\b`, 'i').test(prereq.value)
       );
       return matches;
     })

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -167,6 +167,11 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       .split('-')
       .map((cls) => cls.trim());
 
+    // use the original english class name for determining the feats, if the name was translated with babele
+    let originalClassName;
+    if(this.actorData.class?.flags?.babele?.translated) {
+        originalClassName = this.actorData.class.flags.babele.originalName;
+    }
     let primaryClass = classNames[0];
     let secondaryClass = classNames[1] || null;
 
@@ -174,7 +179,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       this.actorData,
       'class',
       targetLevel,
-      primaryClass
+      originalClassName || primaryClass
     );
     let dualClassFeats = [];
     if (secondaryClass) {

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -14,7 +14,8 @@ import {
 } from './helpers/formHelpers.js';
 import {
   getSkillsForLevel,
-  skillProficiencyRanks
+  skillProficiencyRanks,
+  getSkillTranslation
 } from './helpers/skillsHelpers.js';
 import {
   confirmChanges,
@@ -342,8 +343,8 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
 
     let skillIncreaseMessage = '';
     if (finalData.skills) {
-      const skill = finalData.skills;
-      const normalizedSkill = normalizeString(skill);
+      const normalizedSkill = normalizeString(finalData.skills);
+      const translatedSkill = getSkillTranslation(normalizedSkill);
       const skillRankPath = `system.skills.${normalizedSkill}.rank`;
       const updatedRank = actor.system.skills[normalizedSkill].rank + 1;
       await actor.update({ [skillRankPath]: updatedRank });
@@ -359,7 +360,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
 
       skillIncreaseMessage = game.i18n.format(
         'PF2E_LEVEL_UP_WIZARD.messages.skillIncrease.rankIncrease',
-        { skill, rankName }
+        { skill: translatedSkill, rankName }
       );
     }
 

--- a/templates/level-up-wizard.hbs
+++ b/templates/level-up-wizard.hbs
@@ -155,7 +155,7 @@
           {{localize 'PF2E_LEVEL_UP_WIZARD.menu.dropdown.placeholder'}}
         </option>
         {{#each skills}}
-          <option value={{label}} class={{class}}>{{label}}</option>
+          <option value={{slug}} class={{class}}>{{label}}</option>
         {{/each}}
       </select>
     </div>


### PR DESCRIPTION
Solves https://github.com/BenABaron/pf2e-level-up-wizard/issues/31

Sadly, I could not find a way to support dual classes in a translated system, but they should still work as before when using an englisch system. Otherwise an error notification is displayed.

Polish translation of the notification done with deepl, as I don't speak polish