### PR TITLE
Added SF2e support and PF2e/SF2e Extra Feat Sections support

### DIFF
--- a/src/helpers/featsHelpers.js
+++ b/src/helpers/featsHelpers.js
@@ -9,10 +9,15 @@ let cachedFeats = null;
 const getCachedFeats = async () => {
   if (!cachedFeats) {
     let allFeats = [];
-
-    const defaultCompendium = game.packs.get('pf2e.feats-srd');
-    if (defaultCompendium) {
-      const defaultFeats = await defaultCompendium.getDocuments();
+    
+    const pf2eCompendium = game.packs.get('pf2e.feats-srd');
+    if (pf2eCompendium) {
+      const defaultFeats = await pf2eCompendium.getDocuments();
+      allFeats = allFeats.concat(defaultFeats);
+    }
+    const sf2eCompendium = game.packs.get('sf2e.feats');
+    if(sf2eCompendium) {
+      const defaultFeats = await sf2eCompendium.getDocuments();
       allFeats = allFeats.concat(defaultFeats);
     }
 

--- a/src/helpers/foundryHelpers.js
+++ b/src/helpers/foundryHelpers.js
@@ -135,7 +135,7 @@ export const getClassJournal = async (actor) => {
     : [characterClass];
 
   const classesJournal = game.packs
-    .get('pf2e.journals')
+    .get(game.system.id+'.journals')
     ?.index.find((entry) => entry.name === 'Classes');
 
   if (!classesJournal) return null;

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -167,10 +167,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       );
     const ancestryParagonHawk =   
       game.modules.get('pf2e-sf2e-extra-feat-slots')?.active &&
-      game.settings.get(
-        'pf2e-sf2e-extra-feat-slots',
-        'ancestryParagon'
-      );
+      game.settings.get(game.system.id, "campaignFeatSections").find((section) => section.id === "pf2e-sf2e-extra-feat-slots-ancestry-paragon");
     const showFeatPrerequisites = game.settings.get(
       module_name,
       'show-feat-prerequisites'
@@ -361,7 +358,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       generalFeats: 'general',
       freeArchetypeFeats: 'archetype',
       ancestryParagonFeatsXDY: 'xdy_ancestryparagon',
-      ancestryParagonFeatsHawk: 'ancestryParagon',
+      ancestryParagonFeatsHawk: 'pf2e-sf2e-extra-feat-slots-ancestry-paragon',
       mythicFeats: 'mythic'
     };
 

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -159,11 +159,17 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       game.settings.get(game.system.id, 'mythic') === 'enabled';
     const ABPEnabled =
       game.settings.get(game.system.id, 'automaticBonusVariant') !== 'noABP';
-    const ancestryParagon =
+    const ancestryParagonXDY =
       game.modules.get('xdy-pf2e-workbench')?.active &&
       game.settings.get(
         'xdy-pf2e-workbench',
         'legacyVariantRuleAncestryParagon'
+      );
+    const ancestryParagonHawk =   
+      game.modules.get('pf2e-sf2e-extra-feat-slots')?.active &&
+      game.settings.get(
+        'pf2e-sf2e-extra-feat-slots',
+        'ancestryParagon'
       );
     const showFeatPrerequisites = game.settings.get(
       module_name,
@@ -219,7 +225,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       freeArchetype &&
       (await getFeatsForLevel(this.actorData, 'archetype', targetLevel));
     const ancestryParagonFeats =
-      ancestryParagon &&
+      (ancestryParagonXDY || ancestryParagonHawk) &&
       (await getFeatsForLevel(this.actorData, 'ancestryParagon', targetLevel));
     const {
       hasSkillPotencyUpgrade,
@@ -331,7 +337,8 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       skillFeats: finalData.skillFeats,
       generalFeats: finalData.generalFeats,
       freeArchetypeFeats: finalData.freeArchetypeFeats,
-      ancestryParagonFeats: finalData.ancestryParagonFeats,
+      ancestryParagonFeatsXDY: finalData.ancestryParagonFeats,
+      ancestryParagonFeatsHawk: finalData.ancestryParagonFeats,
       mythicFeats: finalData.mythicFeats
     });
 
@@ -353,7 +360,8 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       skillFeats: 'skill',
       generalFeats: 'general',
       freeArchetypeFeats: 'archetype',
-      ancestryParagonFeats: 'xdy_ancestryparagon',
+      ancestryParagonFeatsXDY: 'xdy_ancestryparagon',
+      ancestryParagonFeatsHawk: 'ancestryParagon',
       mythicFeats: 'mythic'
     };
 

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -159,15 +159,18 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       game.settings.get(game.system.id, 'mythic') === 'enabled';
     const ABPEnabled =
       game.settings.get(game.system.id, 'automaticBonusVariant') !== 'noABP';
-    const ancestryParagonXDY =
+    const ancestryParagon =
       game.modules.get('xdy-pf2e-workbench')?.active &&
       game.settings.get(
         'xdy-pf2e-workbench',
         'legacyVariantRuleAncestryParagon'
       );
-    const ancestryParagonHawk =   
-      game.modules.get('pf2e-sf2e-extra-feat-slots')?.active &&
-      game.settings.get(game.system.id, "campaignFeatSections").find((section) => section.id === "pf2e-sf2e-extra-feat-slots-ancestry-paragon");
+
+
+
+
+
+
     const showFeatPrerequisites = game.settings.get(
       module_name,
       'show-feat-prerequisites'
@@ -222,7 +225,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       freeArchetype &&
       (await getFeatsForLevel(this.actorData, 'archetype', targetLevel));
     const ancestryParagonFeats =
-      (ancestryParagonXDY || ancestryParagonHawk) &&
+      ancestryParagon &&
       (await getFeatsForLevel(this.actorData, 'ancestryParagon', targetLevel));
     const {
       hasSkillPotencyUpgrade,
@@ -334,8 +337,8 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       skillFeats: finalData.skillFeats,
       generalFeats: finalData.generalFeats,
       freeArchetypeFeats: finalData.freeArchetypeFeats,
-      ancestryParagonFeatsXDY: finalData.ancestryParagonFeats,
-      ancestryParagonFeatsHawk: finalData.ancestryParagonFeats,
+      ancestryParagonFeats: finalData.ancestryParagonFeats,
+
       mythicFeats: finalData.mythicFeats
     });
 
@@ -357,8 +360,8 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       skillFeats: 'skill',
       generalFeats: 'general',
       freeArchetypeFeats: 'archetype',
-      ancestryParagonFeatsXDY: 'xdy_ancestryparagon',
-      ancestryParagonFeatsHawk: 'pf2e-sf2e-extra-feat-slots-ancestry-paragon',
+      ancestryParagonFeats: 'xdy_ancestryparagon',
+
       mythicFeats: 'mythic'
     };
 

--- a/src/levelUpWizard.js
+++ b/src/levelUpWizard.js
@@ -154,11 +154,11 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       ? currentLevel
       : currentLevel + 1;
 
-    const freeArchetype = game.settings.get('pf2e', 'freeArchetypeVariant');
+    const freeArchetype = game.settings.get(game.system.id, 'freeArchetypeVariant');
     const mythicVariantEnabled =
-      game.settings.get('pf2e', 'mythic') === 'enabled';
+      game.settings.get(game.system.id, 'mythic') === 'enabled';
     const ABPEnabled =
-      game.settings.get('pf2e', 'automaticBonusVariant') !== 'noABP';
+      game.settings.get(game.system.id, 'automaticBonusVariant') !== 'noABP';
     const ancestryParagon =
       game.modules.get('xdy-pf2e-workbench')?.active &&
       game.settings.get(
@@ -231,7 +231,7 @@ export class PF2eLevelUpWizardConfig extends foundry.applications.api
       ABPEnabled &&
       getSkillPotencyForLevel(this.actorData, targetLevel, ABPEnabled);
 
-    const gradualBoosts = game.settings.get('pf2e', 'gradualBoostsVariant');
+    const gradualBoosts = game.settings.get(game.system.id, 'gradualBoostsVariant');
 
     const {
       featuresForLevel,


### PR DESCRIPTION
unfortunately the feats compendiums have slightly different names, so requires a little more code than just replacing "pf2e." with game.system.id, but settings work fine with this.

Also added support for my own module which has another option for enabling Ancestry Paragon.